### PR TITLE
Add pyinstaller support

### DIFF
--- a/acbfe.spec
+++ b/acbfe.spec
@@ -1,0 +1,44 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['src/acbfe.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('images', './images')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='acbfe',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='acbfe',
+)

--- a/src/constants.py
+++ b/src/constants.py
@@ -40,6 +40,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(exec_path))
 ICON_PATH = ''
 if os.path.isfile(os.path.join(BASE_DIR, 'images/acbfe.png')):
   ICON_PATH = os.path.join(BASE_DIR, 'images')
+# pyinstallyer
+elif os.path.isfile(os.path.join(BASE_DIR, 'acbfe/_internal/images/acbfe.png')):
+  ICON_PATH = os.path.join(BASE_DIR, 'acbfe/_internal/images')
 elif os.path.isfile(os.path.join(os.path.dirname(exec_path), 'images/acbfe.png')):
   ICON_PATH = os.path.join(os.path.dirname(exec_path), 'images')
 elif os.path.isfile(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../images/acbfe.png')):


### PR DESCRIPTION
If you run `pyinstaller acbfe.spec` you should get a `dist` dir with `acbfe` executable with an `_internal` dir.

For Windows/MacOS it needs to be run on those systems but using github actions we can copy/create a script to do it.